### PR TITLE
Create Forms

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@nestjs/common": "^10.0.0",
     "@nestjs/config": "^3.1.1",
     "@nestjs/core": "^10.0.0",
+    "@nestjs/mapped-types": "*",
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/typeorm": "^10.0.1",
     "pg": "^8.11.3",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "@nestjs/mapped-types": "*",
     "@nestjs/platform-express": "^10.0.0",
     "@nestjs/typeorm": "^10.0.1",
+    "class-transformer": "^0.3.1",
+    "class-validator": "^0.14.0",
     "pg": "^8.11.3",
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 dependencies:
   '@nestjs/common':
     specifier: ^10.0.0
-    version: 10.0.0(class-transformer@0.2.3)(class-validator@0.11.1)(reflect-metadata@0.1.13)(rxjs@7.8.1)
+    version: 10.0.0(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)
   '@nestjs/config':
     specifier: ^3.1.1
     version: 3.1.1(@nestjs/common@10.0.0)(reflect-metadata@0.1.13)
@@ -16,13 +16,19 @@ dependencies:
     version: 10.0.0(@nestjs/common@10.0.0)(@nestjs/platform-express@10.0.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)
   '@nestjs/mapped-types':
     specifier: '*'
-    version: 0.0.1(class-transformer@0.2.3)(class-validator@0.11.1)(reflect-metadata@0.1.13)
+    version: 0.0.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)
   '@nestjs/platform-express':
     specifier: ^10.0.0
     version: 10.0.0(@nestjs/common@10.0.0)(@nestjs/core@10.0.0)
   '@nestjs/typeorm':
     specifier: ^10.0.1
     version: 10.0.1(@nestjs/common@10.0.0)(@nestjs/core@10.0.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)(typeorm@0.3.17)
+  class-transformer:
+    specifier: ^0.3.1
+    version: 0.3.1
+  class-validator:
+    specifier: ^0.14.0
+    version: 0.14.0
   pg:
     specifier: ^8.11.3
     version: 8.11.3
@@ -883,7 +889,7 @@ packages:
       - webpack-cli
     dev: true
 
-  /@nestjs/common@10.0.0(class-transformer@0.2.3)(class-validator@0.11.1)(reflect-metadata@0.1.13)(rxjs@7.8.1):
+  /@nestjs/common@10.0.0(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1):
     resolution: {integrity: sha512-Fa2GDQJrO5TTTcpISWfm0pdPS62V+8YbxeG5CA01zMUI+dCO3v3oFf+BSjqCGUUo7GDNzDsjAejwGXuqA54RPw==}
     peerDependencies:
       class-transformer: '*'
@@ -896,8 +902,8 @@ packages:
       class-validator:
         optional: true
     dependencies:
-      class-transformer: 0.2.3
-      class-validator: 0.11.1
+      class-transformer: 0.3.1
+      class-validator: 0.14.0
       iterare: 1.2.1
       reflect-metadata: 0.1.13
       rxjs: 7.8.1
@@ -910,7 +916,7 @@ packages:
       '@nestjs/common': ^8.0.0 || ^9.0.0 || ^10.0.0
       reflect-metadata: ^0.1.13
     dependencies:
-      '@nestjs/common': 10.0.0(class-transformer@0.2.3)(class-validator@0.11.1)(reflect-metadata@0.1.13)(rxjs@7.8.1)
+      '@nestjs/common': 10.0.0(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)
       dotenv: 16.3.1
       dotenv-expand: 10.0.0
       lodash: 4.17.21
@@ -936,7 +942,7 @@ packages:
       '@nestjs/websockets':
         optional: true
     dependencies:
-      '@nestjs/common': 10.0.0(class-transformer@0.2.3)(class-validator@0.11.1)(reflect-metadata@0.1.13)(rxjs@7.8.1)
+      '@nestjs/common': 10.0.0(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)
       '@nestjs/platform-express': 10.0.0(@nestjs/common@10.0.0)(@nestjs/core@10.0.0)
       '@nuxtjs/opencollective': 0.3.2
       fast-safe-stringify: 2.1.1
@@ -949,15 +955,15 @@ packages:
     transitivePeerDependencies:
       - encoding
 
-  /@nestjs/mapped-types@0.0.1(class-transformer@0.2.3)(class-validator@0.11.1)(reflect-metadata@0.1.13):
+  /@nestjs/mapped-types@0.0.1(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.13):
     resolution: {integrity: sha512-4G4Ui7Sj0UqXiZsUFk/6cPD3K7uZEFSElzkOftaJ3/lXW+HUi1/vfWXabF53qrzO1enTRQDxt1plDbP6SsqXEg==}
     peerDependencies:
       class-transformer: ^0.2.3
       class-validator: ^0.11.1
       reflect-metadata: ^0.1.12
     dependencies:
-      class-transformer: 0.2.3
-      class-validator: 0.11.1
+      class-transformer: 0.3.1
+      class-validator: 0.14.0
       reflect-metadata: 0.1.13
     dev: false
 
@@ -967,7 +973,7 @@ packages:
       '@nestjs/common': ^10.0.0
       '@nestjs/core': ^10.0.0
     dependencies:
-      '@nestjs/common': 10.0.0(class-transformer@0.2.3)(class-validator@0.11.1)(reflect-metadata@0.1.13)(rxjs@7.8.1)
+      '@nestjs/common': 10.0.0(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)
       '@nestjs/core': 10.0.0(@nestjs/common@10.0.0)(@nestjs/platform-express@10.0.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)
       body-parser: 1.20.2
       cors: 2.8.5
@@ -1005,7 +1011,7 @@ packages:
       '@nestjs/platform-express':
         optional: true
     dependencies:
-      '@nestjs/common': 10.0.0(class-transformer@0.2.3)(class-validator@0.11.1)(reflect-metadata@0.1.13)(rxjs@7.8.1)
+      '@nestjs/common': 10.0.0(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)
       '@nestjs/core': 10.0.0(@nestjs/common@10.0.0)(@nestjs/platform-express@10.0.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)
       '@nestjs/platform-express': 10.0.0(@nestjs/common@10.0.0)(@nestjs/core@10.0.0)
       tslib: 2.5.3
@@ -1020,7 +1026,7 @@ packages:
       rxjs: ^7.2.0
       typeorm: ^0.3.0
     dependencies:
-      '@nestjs/common': 10.0.0(class-transformer@0.2.3)(class-validator@0.11.1)(reflect-metadata@0.1.13)(rxjs@7.8.1)
+      '@nestjs/common': 10.0.0(class-transformer@0.3.1)(class-validator@0.14.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)
       '@nestjs/core': 10.0.0(@nestjs/common@10.0.0)(@nestjs/platform-express@10.0.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)
       reflect-metadata: 0.1.13
       rxjs: 7.8.1
@@ -1282,8 +1288,8 @@ packages:
       '@types/superagent': 4.1.21
     dev: true
 
-  /@types/validator@10.11.3:
-    resolution: {integrity: sha512-GKF2VnEkMmEeEGvoo03ocrP9ySMuX1ypKazIYMlsjfslfBMhOAtC5dmEWKdJioW4lJN7MZRS88kalTsVClyQ9w==}
+  /@types/validator@13.11.6:
+    resolution: {integrity: sha512-HUgHujPhKuNzgNXBRZKYexwoG+gHKU+tnfPqjWXFghZAnn73JElicMkuSKJyLGr9JgyA8IgK7fj88IyA9rwYeQ==}
 
   /@types/yargs-parser@21.0.3:
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -2002,15 +2008,15 @@ packages:
     resolution: {integrity: sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==}
     dev: true
 
-  /class-transformer@0.2.3:
-    resolution: {integrity: sha512-qsP+0xoavpOlJHuYsQJsN58HXSl8Jvveo+T37rEvCEeRfMWoytAyR0Ua/YsFgpM6AZYZ/og2PJwArwzJl1aXtQ==}
+  /class-transformer@0.3.1:
+    resolution: {integrity: sha512-cKFwohpJbuMovS8xVLmn8N2AUbAuc8pVo4zEfsUVo8qgECOogns1WVk/FkOZoxhOPTyTYFckuoH+13FO+MQ8GA==}
 
-  /class-validator@0.11.1:
-    resolution: {integrity: sha512-6CGdjwJLmKw+sQbK5ZDo1v1yTajkqfPOUDWSYVIlhUiCh6Phy8sAnMFE2XKHAcKAdoOz4jJUQhjPQWPYUuHxrA==}
+  /class-validator@0.14.0:
+    resolution: {integrity: sha512-ct3ltplN8I9fOwUd8GrP8UQixwff129BkEtuWDKL5W45cQuLd19xqmTLu5ge78YDm/fdje6FMt0hGOhl0lii3A==}
     dependencies:
-      '@types/validator': 10.11.3
-      google-libphonenumber: 3.2.33
-      validator: 12.0.0
+      '@types/validator': 13.11.6
+      libphonenumber-js: 1.10.49
+      validator: 13.11.0
 
   /cli-cursor@3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
@@ -2980,10 +2986,6 @@ packages:
       slash: 3.0.0
     dev: true
 
-  /google-libphonenumber@3.2.33:
-    resolution: {integrity: sha512-1QKCvAlfq8zY1mviORI9lDzM3I/hwm9+h0CwYBTLq59DBbSHMd5zBOLqHZFiBLicRpwIz46Nynvbywj1XApKvA==}
-    engines: {node: '>=0.10'}
-
   /gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
     dependencies:
@@ -3839,6 +3841,9 @@ packages:
       prelude-ls: 1.2.1
       type-check: 0.4.0
     dev: true
+
+  /libphonenumber-js@1.10.49:
+    resolution: {integrity: sha512-gvLtyC3tIuqfPzjvYLH9BmVdqzGDiSi4VjtWe2fAgSdBf0yt8yPmbNnRIHNbR5IdtVkm0ayGuzwQKTWmU0hdjQ==}
 
   /lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
@@ -5424,8 +5429,8 @@ packages:
       convert-source-map: 2.0.0
     dev: true
 
-  /validator@12.0.0:
-    resolution: {integrity: sha512-r5zA1cQBEOgYlesRmSEwc9LkbfNLTtji+vWyaHzRZUxCTHdsX3bd+sdHfs5tGZ2W6ILGGsxWxCNwT/h3IY/3ng==}
+  /validator@13.11.0:
+    resolution: {integrity: sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==}
     engines: {node: '>= 0.10'}
 
   /vary@1.1.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,13 +7,16 @@ settings:
 dependencies:
   '@nestjs/common':
     specifier: ^10.0.0
-    version: 10.0.0(reflect-metadata@0.1.13)(rxjs@7.8.1)
+    version: 10.0.0(class-transformer@0.2.3)(class-validator@0.11.1)(reflect-metadata@0.1.13)(rxjs@7.8.1)
   '@nestjs/config':
     specifier: ^3.1.1
     version: 3.1.1(@nestjs/common@10.0.0)(reflect-metadata@0.1.13)
   '@nestjs/core':
     specifier: ^10.0.0
     version: 10.0.0(@nestjs/common@10.0.0)(@nestjs/platform-express@10.0.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)
+  '@nestjs/mapped-types':
+    specifier: '*'
+    version: 0.0.1(class-transformer@0.2.3)(class-validator@0.11.1)(reflect-metadata@0.1.13)
   '@nestjs/platform-express':
     specifier: ^10.0.0
     version: 10.0.0(@nestjs/common@10.0.0)(@nestjs/core@10.0.0)
@@ -880,7 +883,7 @@ packages:
       - webpack-cli
     dev: true
 
-  /@nestjs/common@10.0.0(reflect-metadata@0.1.13)(rxjs@7.8.1):
+  /@nestjs/common@10.0.0(class-transformer@0.2.3)(class-validator@0.11.1)(reflect-metadata@0.1.13)(rxjs@7.8.1):
     resolution: {integrity: sha512-Fa2GDQJrO5TTTcpISWfm0pdPS62V+8YbxeG5CA01zMUI+dCO3v3oFf+BSjqCGUUo7GDNzDsjAejwGXuqA54RPw==}
     peerDependencies:
       class-transformer: '*'
@@ -893,6 +896,8 @@ packages:
       class-validator:
         optional: true
     dependencies:
+      class-transformer: 0.2.3
+      class-validator: 0.11.1
       iterare: 1.2.1
       reflect-metadata: 0.1.13
       rxjs: 7.8.1
@@ -905,7 +910,7 @@ packages:
       '@nestjs/common': ^8.0.0 || ^9.0.0 || ^10.0.0
       reflect-metadata: ^0.1.13
     dependencies:
-      '@nestjs/common': 10.0.0(reflect-metadata@0.1.13)(rxjs@7.8.1)
+      '@nestjs/common': 10.0.0(class-transformer@0.2.3)(class-validator@0.11.1)(reflect-metadata@0.1.13)(rxjs@7.8.1)
       dotenv: 16.3.1
       dotenv-expand: 10.0.0
       lodash: 4.17.21
@@ -931,7 +936,7 @@ packages:
       '@nestjs/websockets':
         optional: true
     dependencies:
-      '@nestjs/common': 10.0.0(reflect-metadata@0.1.13)(rxjs@7.8.1)
+      '@nestjs/common': 10.0.0(class-transformer@0.2.3)(class-validator@0.11.1)(reflect-metadata@0.1.13)(rxjs@7.8.1)
       '@nestjs/platform-express': 10.0.0(@nestjs/common@10.0.0)(@nestjs/core@10.0.0)
       '@nuxtjs/opencollective': 0.3.2
       fast-safe-stringify: 2.1.1
@@ -944,13 +949,25 @@ packages:
     transitivePeerDependencies:
       - encoding
 
+  /@nestjs/mapped-types@0.0.1(class-transformer@0.2.3)(class-validator@0.11.1)(reflect-metadata@0.1.13):
+    resolution: {integrity: sha512-4G4Ui7Sj0UqXiZsUFk/6cPD3K7uZEFSElzkOftaJ3/lXW+HUi1/vfWXabF53qrzO1enTRQDxt1plDbP6SsqXEg==}
+    peerDependencies:
+      class-transformer: ^0.2.3
+      class-validator: ^0.11.1
+      reflect-metadata: ^0.1.12
+    dependencies:
+      class-transformer: 0.2.3
+      class-validator: 0.11.1
+      reflect-metadata: 0.1.13
+    dev: false
+
   /@nestjs/platform-express@10.0.0(@nestjs/common@10.0.0)(@nestjs/core@10.0.0):
     resolution: {integrity: sha512-jOQBPVpk7B4JFXZZwxHSsY6odIqZlea9CbqKzu/hfDyqRv+AwuJk5gprvvL6RpWAHNyRMH1r5/14bqcXD3+WGw==}
     peerDependencies:
       '@nestjs/common': ^10.0.0
       '@nestjs/core': ^10.0.0
     dependencies:
-      '@nestjs/common': 10.0.0(reflect-metadata@0.1.13)(rxjs@7.8.1)
+      '@nestjs/common': 10.0.0(class-transformer@0.2.3)(class-validator@0.11.1)(reflect-metadata@0.1.13)(rxjs@7.8.1)
       '@nestjs/core': 10.0.0(@nestjs/common@10.0.0)(@nestjs/platform-express@10.0.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)
       body-parser: 1.20.2
       cors: 2.8.5
@@ -988,7 +1005,7 @@ packages:
       '@nestjs/platform-express':
         optional: true
     dependencies:
-      '@nestjs/common': 10.0.0(reflect-metadata@0.1.13)(rxjs@7.8.1)
+      '@nestjs/common': 10.0.0(class-transformer@0.2.3)(class-validator@0.11.1)(reflect-metadata@0.1.13)(rxjs@7.8.1)
       '@nestjs/core': 10.0.0(@nestjs/common@10.0.0)(@nestjs/platform-express@10.0.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)
       '@nestjs/platform-express': 10.0.0(@nestjs/common@10.0.0)(@nestjs/core@10.0.0)
       tslib: 2.5.3
@@ -1003,7 +1020,7 @@ packages:
       rxjs: ^7.2.0
       typeorm: ^0.3.0
     dependencies:
-      '@nestjs/common': 10.0.0(reflect-metadata@0.1.13)(rxjs@7.8.1)
+      '@nestjs/common': 10.0.0(class-transformer@0.2.3)(class-validator@0.11.1)(reflect-metadata@0.1.13)(rxjs@7.8.1)
       '@nestjs/core': 10.0.0(@nestjs/common@10.0.0)(@nestjs/platform-express@10.0.0)(reflect-metadata@0.1.13)(rxjs@7.8.1)
       reflect-metadata: 0.1.13
       rxjs: 7.8.1
@@ -1264,6 +1281,9 @@ packages:
     dependencies:
       '@types/superagent': 4.1.21
     dev: true
+
+  /@types/validator@10.11.3:
+    resolution: {integrity: sha512-GKF2VnEkMmEeEGvoo03ocrP9ySMuX1ypKazIYMlsjfslfBMhOAtC5dmEWKdJioW4lJN7MZRS88kalTsVClyQ9w==}
 
   /@types/yargs-parser@21.0.3:
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -1981,6 +2001,16 @@ packages:
   /cjs-module-lexer@1.2.3:
     resolution: {integrity: sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==}
     dev: true
+
+  /class-transformer@0.2.3:
+    resolution: {integrity: sha512-qsP+0xoavpOlJHuYsQJsN58HXSl8Jvveo+T37rEvCEeRfMWoytAyR0Ua/YsFgpM6AZYZ/og2PJwArwzJl1aXtQ==}
+
+  /class-validator@0.11.1:
+    resolution: {integrity: sha512-6CGdjwJLmKw+sQbK5ZDo1v1yTajkqfPOUDWSYVIlhUiCh6Phy8sAnMFE2XKHAcKAdoOz4jJUQhjPQWPYUuHxrA==}
+    dependencies:
+      '@types/validator': 10.11.3
+      google-libphonenumber: 3.2.33
+      validator: 12.0.0
 
   /cli-cursor@3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
@@ -2949,6 +2979,10 @@ packages:
       merge2: 1.4.1
       slash: 3.0.0
     dev: true
+
+  /google-libphonenumber@3.2.33:
+    resolution: {integrity: sha512-1QKCvAlfq8zY1mviORI9lDzM3I/hwm9+h0CwYBTLq59DBbSHMd5zBOLqHZFiBLicRpwIz46Nynvbywj1XApKvA==}
+    engines: {node: '>=0.10'}
 
   /gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
@@ -5389,6 +5423,10 @@ packages:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
     dev: true
+
+  /validator@12.0.0:
+    resolution: {integrity: sha512-r5zA1cQBEOgYlesRmSEwc9LkbfNLTtji+vWyaHzRZUxCTHdsX3bd+sdHfs5tGZ2W6ILGGsxWxCNwT/h3IY/3ng==}
+    engines: {node: '>= 0.10'}
 
   /vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import { FormsModule } from './forms/forms.module';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
       autoLoadEntities: true,
       synchronize: true,
     }),
+    FormsModule,
   ],
   controllers: [],
   providers: [],

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
+
 import { FormsModule } from './forms/forms.module';
+import { ReceiptsModule } from './receipts/receipts.module';
 
 @Module({
   imports: [
@@ -17,6 +19,7 @@ import { FormsModule } from './forms/forms.module';
       synchronize: true,
     }),
     FormsModule,
+    ReceiptsModule,
   ],
   controllers: [],
   providers: [],

--- a/src/forms/dto/create-form.dto.ts
+++ b/src/forms/dto/create-form.dto.ts
@@ -1,0 +1,1 @@
+export class CreateFormDto {}

--- a/src/forms/dto/create-form.dto.ts
+++ b/src/forms/dto/create-form.dto.ts
@@ -1,1 +1,29 @@
-export class CreateFormDto {}
+import { Type } from 'class-transformer';
+import {
+  IsArray,
+  IsNumber,
+  IsPositive,
+  IsString,
+  MinLength,
+  ValidateNested,
+} from 'class-validator';
+import { CreateReceiptDto } from 'src/receipts/dto/create-receipt.dto';
+
+export class CreateFormDto {
+  @IsString()
+  @MinLength(1)
+  companyName: string;
+
+  @IsString()
+  @MinLength(3)
+  fiscalCode: string;
+
+  @IsNumber()
+  @IsPositive()
+  clientNumber: number;
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CreateReceiptDto)
+  receipts: CreateReceiptDto[];
+}

--- a/src/forms/dto/index.ts
+++ b/src/forms/dto/index.ts
@@ -1,0 +1,2 @@
+export { CreateFormDto } from './create-form.dto';
+export { UpdateFormDto } from './update-form.dto';

--- a/src/forms/dto/update-form.dto.ts
+++ b/src/forms/dto/update-form.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateFormDto } from './create-form.dto';
+
+export class UpdateFormDto extends PartialType(CreateFormDto) {}

--- a/src/forms/dto/update-form.dto.ts
+++ b/src/forms/dto/update-form.dto.ts
@@ -1,4 +1,7 @@
-import { PartialType } from '@nestjs/mapped-types';
-import { CreateFormDto } from './create-form.dto';
+import { IsEnum } from 'class-validator';
+import { FormStatus } from '../enums/form-status.enum';
 
-export class UpdateFormDto extends PartialType(CreateFormDto) {}
+export class UpdateFormDto {
+  @IsEnum(FormStatus)
+  formStatus: FormStatus;
+}

--- a/src/forms/entities/form.entity.ts
+++ b/src/forms/entities/form.entity.ts
@@ -1,0 +1,1 @@
+export class Form {}

--- a/src/forms/entities/form.entity.ts
+++ b/src/forms/entities/form.entity.ts
@@ -1,6 +1,7 @@
 import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 
 import { Receipt } from 'src/receipts/entities/receipt.entity';
+import { FormStatus } from '../enums/form-status.enum';
 
 @Entity()
 export class Form {
@@ -15,6 +16,14 @@ export class Form {
 
   @Column({ name: 'client_number', type: 'numeric' })
   clientNumber: number;
+
+  @Column({
+    name: 'form_status',
+    type: 'enum',
+    enum: FormStatus,
+    default: FormStatus.PENDING,
+  })
+  formStatus: FormStatus;
 
   @OneToMany(() => Receipt, (receipt) => receipt.form)
   receipts: Receipt[];

--- a/src/forms/entities/form.entity.ts
+++ b/src/forms/entities/form.entity.ts
@@ -1,1 +1,21 @@
-export class Form {}
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+
+import { Receipt } from 'src/receipts/entities/receipt.entity';
+
+@Entity()
+export class Form {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'company_name', type: 'text' })
+  companyName: string;
+
+  @Column({ name: 'fiscal_code', type: 'text' })
+  fiscalCode: string;
+
+  @Column({ name: 'client_number', type: 'int' })
+  clientNumber: number;
+
+  @OneToMany(() => Receipt, (receipt) => receipt.form, { eager: true })
+  receipts: Receipt[];
+}

--- a/src/forms/entities/form.entity.ts
+++ b/src/forms/entities/form.entity.ts
@@ -13,9 +13,9 @@ export class Form {
   @Column({ name: 'fiscal_code', type: 'text' })
   fiscalCode: string;
 
-  @Column({ name: 'client_number', type: 'int' })
+  @Column({ name: 'client_number', type: 'numeric' })
   clientNumber: number;
 
-  @OneToMany(() => Receipt, (receipt) => receipt.form, { eager: true })
+  @OneToMany(() => Receipt, (receipt) => receipt.form)
   receipts: Receipt[];
 }

--- a/src/forms/enums/form-status.enum.ts
+++ b/src/forms/enums/form-status.enum.ts
@@ -1,0 +1,5 @@
+export enum FormStatus {
+  PENDING = 'PENDING',
+  APPROVED = 'APPROVED',
+  REJECTED = 'REJECTED',
+}

--- a/src/forms/forms.controller.ts
+++ b/src/forms/forms.controller.ts
@@ -1,0 +1,42 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+} from '@nestjs/common';
+import { FormsService } from './forms.service';
+import { CreateFormDto } from './dto/create-form.dto';
+import { UpdateFormDto } from './dto/update-form.dto';
+
+@Controller('forms')
+export class FormsController {
+  constructor(private readonly formsService: FormsService) {}
+
+  @Post()
+  create(@Body() createFormDto: CreateFormDto) {
+    return this.formsService.create(createFormDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.formsService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.formsService.findOne(+id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() updateFormDto: UpdateFormDto) {
+    return this.formsService.update(+id, updateFormDto);
+  }
+
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.formsService.remove(+id);
+  }
+}

--- a/src/forms/forms.controller.ts
+++ b/src/forms/forms.controller.ts
@@ -1,4 +1,11 @@
-import { Controller, Get, Post, Body, Param } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  ParseUUIDPipe,
+} from '@nestjs/common';
 
 import { FormsService } from './forms.service';
 import { CreateFormDto } from './dto';
@@ -18,7 +25,7 @@ export class FormsController {
   }
 
   @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.formsService.findOne(+id);
+  findOne(@Param('id', ParseUUIDPipe) id: string) {
+    return this.formsService.findOne(id);
   }
 }

--- a/src/forms/forms.controller.ts
+++ b/src/forms/forms.controller.ts
@@ -1,15 +1,7 @@
-import {
-  Controller,
-  Get,
-  Post,
-  Body,
-  Patch,
-  Param,
-  Delete,
-} from '@nestjs/common';
+import { Controller, Get, Post, Body, Param } from '@nestjs/common';
+
 import { FormsService } from './forms.service';
-import { CreateFormDto } from './dto/create-form.dto';
-import { UpdateFormDto } from './dto/update-form.dto';
+import { CreateFormDto } from './dto';
 
 @Controller('forms')
 export class FormsController {
@@ -28,15 +20,5 @@ export class FormsController {
   @Get(':id')
   findOne(@Param('id') id: string) {
     return this.formsService.findOne(+id);
-  }
-
-  @Patch(':id')
-  update(@Param('id') id: string, @Body() updateFormDto: UpdateFormDto) {
-    return this.formsService.update(+id, updateFormDto);
-  }
-
-  @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.formsService.remove(+id);
   }
 }

--- a/src/forms/forms.controller.ts
+++ b/src/forms/forms.controller.ts
@@ -5,10 +5,11 @@ import {
   Body,
   Param,
   ParseUUIDPipe,
+  Patch,
 } from '@nestjs/common';
 
 import { FormsService } from './forms.service';
-import { CreateFormDto } from './dto';
+import { CreateFormDto, UpdateFormDto } from './dto';
 
 @Controller('forms')
 export class FormsController {
@@ -27,5 +28,13 @@ export class FormsController {
   @Get(':id')
   findOne(@Param('id', ParseUUIDPipe) id: string) {
     return this.formsService.findOne(id);
+  }
+
+  @Patch(':id')
+  update(
+    @Param('id', ParseUUIDPipe) id: string,
+    @Body() updateFormDto: UpdateFormDto,
+  ) {
+    return this.formsService.update(id, updateFormDto);
   }
 }

--- a/src/forms/forms.module.ts
+++ b/src/forms/forms.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { FormsService } from './forms.service';
+import { FormsController } from './forms.controller';
+
+@Module({
+  controllers: [FormsController],
+  providers: [FormsService],
+})
+export class FormsModule {}

--- a/src/forms/forms.module.ts
+++ b/src/forms/forms.module.ts
@@ -1,9 +1,13 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { Form } from './entities/form.entity';
 import { FormsService } from './forms.service';
 import { FormsController } from './forms.controller';
 
 @Module({
   controllers: [FormsController],
   providers: [FormsService],
+  imports: [TypeOrmModule.forFeature([Form])],
 })
 export class FormsModule {}

--- a/src/forms/forms.module.ts
+++ b/src/forms/forms.module.ts
@@ -5,9 +5,11 @@ import { Form } from './entities/form.entity';
 import { FormsService } from './forms.service';
 import { FormsController } from './forms.controller';
 
+import { ReceiptsModule } from '../receipts/receipts.module';
+
 @Module({
   controllers: [FormsController],
   providers: [FormsService],
-  imports: [TypeOrmModule.forFeature([Form])],
+  imports: [TypeOrmModule.forFeature([Form]), ReceiptsModule],
 })
 export class FormsModule {}

--- a/src/forms/forms.service.ts
+++ b/src/forms/forms.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@nestjs/common';
+import { CreateFormDto } from './dto/create-form.dto';
+import { UpdateFormDto } from './dto/update-form.dto';
+
+@Injectable()
+export class FormsService {
+  create(createFormDto: CreateFormDto) {
+    console.log({ createFormDto });
+    return 'This action adds a new form';
+  }
+
+  findAll() {
+    return `This action returns all forms`;
+  }
+
+  findOne(id: number) {
+    return `This action returns a #${id} form`;
+  }
+
+  update(id: number, updateFormDto: UpdateFormDto) {
+    console.log({ updateFormDto });
+    return `This action updates a #${id} form`;
+  }
+
+  remove(id: number) {
+    return `This action removes a #${id} form`;
+  }
+}

--- a/src/forms/forms.service.ts
+++ b/src/forms/forms.service.ts
@@ -1,19 +1,50 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
 
 import { CreateFormDto } from './dto';
+import { Form } from './entities/form.entity';
+import { ReceiptsService } from '../receipts/receipts.service';
 
 @Injectable()
 export class FormsService {
-  create(createFormDto: CreateFormDto) {
-    console.log({ createFormDto });
-    return 'This action adds a new form';
+  constructor(
+    @InjectRepository(Form)
+    private readonly formRepository: Repository<Form>,
+    private readonly receiptsService: ReceiptsService,
+  ) {}
+
+  async create(createFormDto: CreateFormDto): Promise<Form> {
+    const { receipts, ...rest } = createFormDto;
+
+    const form = this.formRepository.create({
+      ...rest,
+      receipts: await Promise.all(
+        receipts.map(
+          async (receipt) => await this.receiptsService.create(receipt),
+        ),
+      ),
+    });
+
+    await this.formRepository.save(form);
+
+    return form;
   }
 
-  findAll() {
-    return `This action returns all forms`;
+  async findAll(): Promise<Form[]> {
+    const forms = await this.formRepository.find();
+
+    return forms;
   }
 
-  findOne(id: number) {
-    return `This action returns a #${id} form`;
+  async findOne(id: string): Promise<Form> {
+    const form = await this.formRepository.findOne({
+      where: { id },
+      relations: ['receipts'],
+    });
+
+    if (!form) throw new NotFoundException(`Form #${id} not found`);
+
+    return form;
   }
 }

--- a/src/forms/forms.service.ts
+++ b/src/forms/forms.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
-import { CreateFormDto } from './dto/create-form.dto';
-import { UpdateFormDto } from './dto/update-form.dto';
+
+import { CreateFormDto } from './dto';
 
 @Injectable()
 export class FormsService {
@@ -15,14 +15,5 @@ export class FormsService {
 
   findOne(id: number) {
     return `This action returns a #${id} form`;
-  }
-
-  update(id: number, updateFormDto: UpdateFormDto) {
-    console.log({ updateFormDto });
-    return `This action updates a #${id} form`;
-  }
-
-  remove(id: number) {
-    return `This action removes a #${id} form`;
   }
 }

--- a/src/forms/forms.service.ts
+++ b/src/forms/forms.service.ts
@@ -2,7 +2,7 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 
-import { CreateFormDto } from './dto';
+import { CreateFormDto, UpdateFormDto } from './dto';
 import { Form } from './entities/form.entity';
 import { ReceiptsService } from '../receipts/receipts.service';
 
@@ -29,6 +29,18 @@ export class FormsService {
     await this.formRepository.save(form);
 
     return form;
+  }
+
+  async update(id: string, updateFormDto: UpdateFormDto): Promise<Form> {
+    const form = await this.findOne(id);
+
+    const updatedForm = await this.formRepository.preload({
+      ...form,
+      ...updateFormDto,
+    });
+    await this.formRepository.save(updatedForm);
+
+    return updatedForm;
   }
 
   async findAll(): Promise<Form[]> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,18 @@
 import { NestFactory } from '@nestjs/core';
+import { ValidationPipe } from '@nestjs/common';
+
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+    }),
+  );
+
   await app.listen(+process.env.PORT || 3000);
 }
 bootstrap();

--- a/src/receipts/dto/create-receipt.dto.ts
+++ b/src/receipts/dto/create-receipt.dto.ts
@@ -1,0 +1,16 @@
+import { IsDate, IsNumber, IsPositive } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class CreateReceiptDto {
+  @IsDate()
+  @Type(() => Date)
+  receiptDate: Date;
+
+  @IsNumber()
+  @IsPositive()
+  taxAmount: number;
+
+  @IsNumber()
+  @IsPositive()
+  taxPercentage: number;
+}

--- a/src/receipts/entities/receipt.entity.ts
+++ b/src/receipts/entities/receipt.entity.ts
@@ -10,10 +10,10 @@ export class Receipt {
   @Column({ name: 'receipt_date', type: 'date' })
   receiptDate: Date;
 
-  @Column({ name: 'tax_amount', type: 'float' })
+  @Column({ name: 'tax_amount', type: 'numeric' })
   taxAmount: number;
 
-  @Column({ name: 'tax_percentage', type: 'float' })
+  @Column({ name: 'tax_percentage', type: 'numeric' })
   taxPercentage: number;
 
   @ManyToOne(() => Form, (form) => form.receipts)

--- a/src/receipts/entities/receipt.entity.ts
+++ b/src/receipts/entities/receipt.entity.ts
@@ -1,0 +1,21 @@
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm';
+
+import { Form } from 'src/forms/entities/form.entity';
+
+@Entity()
+export class Receipt {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'receipt_date', type: 'date' })
+  receiptDate: Date;
+
+  @Column({ name: 'tax_amount', type: 'float' })
+  taxAmount: number;
+
+  @Column({ name: 'tax_percentage', type: 'float' })
+  taxPercentage: number;
+
+  @ManyToOne(() => Form, (form) => form.receipts)
+  form: Form;
+}

--- a/src/receipts/receipts.controller.ts
+++ b/src/receipts/receipts.controller.ts
@@ -1,0 +1,7 @@
+import { Controller } from '@nestjs/common';
+import { ReceiptsService } from './receipts.service';
+
+@Controller('receipts')
+export class ReceiptsController {
+  constructor(private readonly receiptsService: ReceiptsService) {}
+}

--- a/src/receipts/receipts.module.ts
+++ b/src/receipts/receipts.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { ReceiptsService } from './receipts.service';
+import { ReceiptsController } from './receipts.controller';
+
+@Module({
+  controllers: [ReceiptsController],
+  providers: [ReceiptsService],
+})
+export class ReceiptsModule {}

--- a/src/receipts/receipts.module.ts
+++ b/src/receipts/receipts.module.ts
@@ -9,5 +9,6 @@ import { ReceiptsController } from './receipts.controller';
   controllers: [ReceiptsController],
   providers: [ReceiptsService],
   imports: [TypeOrmModule.forFeature([Receipt])],
+  exports: [ReceiptsService],
 })
 export class ReceiptsModule {}

--- a/src/receipts/receipts.module.ts
+++ b/src/receipts/receipts.module.ts
@@ -1,9 +1,13 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { Receipt } from './entities/receipt.entity';
 import { ReceiptsService } from './receipts.service';
 import { ReceiptsController } from './receipts.controller';
 
 @Module({
   controllers: [ReceiptsController],
   providers: [ReceiptsService],
+  imports: [TypeOrmModule.forFeature([Receipt])],
 })
 export class ReceiptsModule {}

--- a/src/receipts/receipts.service.ts
+++ b/src/receipts/receipts.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ReceiptsService {}

--- a/src/receipts/receipts.service.ts
+++ b/src/receipts/receipts.service.ts
@@ -1,4 +1,20 @@
 import { Injectable } from '@nestjs/common';
+import { CreateReceiptDto } from './dto/create-receipt.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Receipt } from './entities/receipt.entity';
+import { Repository } from 'typeorm';
 
 @Injectable()
-export class ReceiptsService {}
+export class ReceiptsService {
+  constructor(
+    @InjectRepository(Receipt)
+    private readonly receiptRepository: Repository<Receipt>,
+  ) {}
+
+  async create(createReceiptDto: CreateReceiptDto): Promise<Receipt> {
+    const receipt = this.receiptRepository.create(createReceiptDto);
+    await this.receiptRepository.save(receipt);
+
+    return receipt;
+  }
+}


### PR DESCRIPTION
## Create Forms and Receipts.

This PR adds the functionality to create new `Forms` and modify their status as convenient.

## Assumptions

Two new resources for the application were created: `Forms` and `Receipts`.  The reason behind this decision states as follows. 
A `Receipt` is a complex entity that could scale easily to support different use cases such as file uploading or, a user may want to add receipts to an already created `Form`. This way, by handling `Receipts` as a separate resource we could easily extend our current implementation.

## Description

- Create database entities.
- Integrate `class-validator` and `class-transformer` package for data validation and sanitization.
- Create CRUD operations for `Forms`.
- Create `receiptService` to handle the creation of receipts when provided during the `Form` creation.
- Make `receiptService` available through dependency injection by exporting the service from `receiptModule`.
- Create endpoint and validation to handle the form's approval.

## Notes

- Some restrictions could be applied as making the company name unique but, as any of these were not mentioned in the challenge, they were not included to save some time and prioritize others.
