### PR TITLE
Validate fiscal

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,6 +4,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { FormsModule } from './forms/forms.module';
 import { ReceiptsModule } from './receipts/receipts.module';
+import { ValidatorModule } from './validator/validator.module';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { ReceiptsModule } from './receipts/receipts.module';
     }),
     FormsModule,
     ReceiptsModule,
+    ValidatorModule,
   ],
   controllers: [],
   providers: [],

--- a/src/common/constants/fiscalIdRegex.ts
+++ b/src/common/constants/fiscalIdRegex.ts
@@ -1,0 +1,10 @@
+export const fiscalIdRegex = /^[A-Za-z0-9]{4}-[A-Za-z0-9]{4}-[A-Za-z0-9]{2}$/;
+/* 
+Examples of valid fiscal IDs:
+ABCD-1234-EF
+WXYZ-5678-GH
+LMNO-9876-IJ
+1234-ABCD-XY
+5678-WXYZ-ZZ
+9ABC-DEF1-23
+*/

--- a/src/forms/dto/create-form.dto.ts
+++ b/src/forms/dto/create-form.dto.ts
@@ -15,7 +15,6 @@ export class CreateFormDto {
   companyName: string;
 
   @IsString()
-  @MinLength(3)
   fiscalCode: string;
 
   @IsNumber()

--- a/src/forms/entities/form.entity.ts
+++ b/src/forms/entities/form.entity.ts
@@ -14,6 +14,9 @@ export class Form {
   @Column({ name: 'fiscal_code', type: 'text' })
   fiscalCode: string;
 
+  @Column({ name: 'valid_fiscal_code', type: 'boolean' })
+  validFiscalCode: boolean;
+
   @Column({ name: 'client_number', type: 'numeric' })
   clientNumber: number;
 

--- a/src/forms/forms.module.ts
+++ b/src/forms/forms.module.ts
@@ -6,10 +6,11 @@ import { FormsService } from './forms.service';
 import { FormsController } from './forms.controller';
 
 import { ReceiptsModule } from '../receipts/receipts.module';
+import { ValidatorModule } from '../validator/validator.module';
 
 @Module({
   controllers: [FormsController],
   providers: [FormsService],
-  imports: [TypeOrmModule.forFeature([Form]), ReceiptsModule],
+  imports: [TypeOrmModule.forFeature([Form]), ReceiptsModule, ValidatorModule],
 })
 export class FormsModule {}

--- a/src/validator/validator.controller.ts
+++ b/src/validator/validator.controller.ts
@@ -1,0 +1,7 @@
+import { Controller } from '@nestjs/common';
+import { ValidatorService } from './validator.service';
+
+@Controller('validator')
+export class ValidatorController {
+  constructor(private readonly validatorService: ValidatorService) {}
+}

--- a/src/validator/validator.module.ts
+++ b/src/validator/validator.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ValidatorService } from './validator.service';
+import { ValidatorController } from './validator.controller';
+
+@Module({
+  controllers: [ValidatorController],
+  providers: [ValidatorService],
+  exports: [ValidatorService],
+})
+export class ValidatorModule {}

--- a/src/validator/validator.service.ts
+++ b/src/validator/validator.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@nestjs/common';
+import { fiscalIdRegex } from 'src/common/constants/fiscalIdRegex';
+
+@Injectable()
+export class ValidatorService {
+  async validateFiscalId(fiscalId: string): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+      setTimeout(() => {
+        const isValid = fiscalIdRegex.test(fiscalId);
+        resolve(isValid);
+      }, 1000);
+    });
+  }
+}


### PR DESCRIPTION
## Validate Fiscal ID Code

This PR adds to functionality to validate the `fiscal Id code` provided during the creation of the form.

## Assumptions.

- I've created a regular expression to validate against. A list of valid examples can be found in the file `fiscalIdRegex.ts`.
- Fiscal codes that match the expression will be taken as valid and the ones who don’t will be taken as invalid.
- I've created a `validatorService` with a promise to emulate the communication with an external service. In the future when this service was provided we can make the integration in it.
- I'm assuming the response time for the external service is not too long.

## Diagram

<img width="891" alt="image" src="https://github.com/Alejoboga20/finalis-code-challenge-server/assets/60139228/fbce6ed9-2839-47c1-9809-9d2caafbae12">

